### PR TITLE
Set a default value for the nameserver

### DIFF
--- a/dhc_images/root.d/99-set-nameserver
+++ b/dhc_images/root.d/99-set-nameserver
@@ -27,5 +27,5 @@ if [ -f $RESOLV_CONF ];
 then
     # Some upstream images tend to have some random ips in the resolv.conf file
     echo "Reset resolv.conf configuration"
-    sudo sh -c "echo '' > $RESOLV_CONF"
+    sudo sh -c "echo 'nameserver 8.8.8.8' > $RESOLV_CONF"
 fi


### PR DESCRIPTION
Working around an issue with cloud-init on debian

Change-Id: I8cc28a1d25ff32e028172b955536f07c809a1c0e
Signed-off-by: Rosario Di Somma rosario.disomma@gmail.com
