### PR TITLE
Add Fedora 25 image

### DIFF
--- a/dhc_fedora25/element-deps
+++ b/dhc_fedora25/element-deps
@@ -1,0 +1,2 @@
+dhc_base
+fedora


### PR DESCRIPTION
The Fedora 25 image should work as is.  There is a slight bug in older
versions of DIB, so diskimage-builder needs to be at least version
1.26.1 in order for this to build cleanly.