### PR TITLE
attempting to fix debian-systemd with upstream additions

### DIFF
--- a/dhc_debian7/root.d/05-debian-systemd
+++ b/dhc_debian7/root.d/05-debian-systemd
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+cat > ${TARGET_ROOT}/.extra_settings << EOF
+DIB_DEBIAN_ALT_INIT_PACKAGE=systemd-sysv
+EOF


### PR DESCRIPTION
debian-systemd doesn't use --force-yes when replacing sysvinit and fails due to "Are you really REALLY sure" BS. I'm not really sure if this is the fix needed, but it is specifically related to debian-systemd.